### PR TITLE
added trailing slash to Home link - to properly handle root urls

### DIFF
--- a/templates/archives.html
+++ b/templates/archives.html
@@ -10,11 +10,11 @@
         <nav id="navigation">
           {% if SITE_LOGO %}
             <span class="blog-logo">
-                <a href="{{ SITEURL }}"><img src="{{SITE_LOGO}}" alt="Blog Logo" /></a>
+                <a href="{{ SITEURL }}/"><img src="{{SITE_LOGO}}" alt="Blog Logo" /></a>
             </span>
           {% else %}
             <span id="home-button" class="nav-button">
-                <a class="home-button" href="{{ SITEURL }}" title="Home"><i class="ic ic-arrow-left"></i> Home</a>
+                <a class="home-button" href="{{ SITEURL }}/" title="Home"><i class="ic ic-arrow-left"></i> Home</a>
             </span>
           {% endif %}
           <span id="menu-button" class="nav-button">
@@ -23,14 +23,14 @@
         </nav>
         <h1 class="post-title">{{ SITENAME }} - Archives</h1>
         {% if HEADER_COVER %}
-            <div class="blog-cover cover" style="background-image: url('{{ HEADER_COVER }}')">            
+            <div class="blog-cover cover" style="background-image: url('{{ HEADER_COVER }}')">
         {% elif HEADER_COLOR %}
             <div class="post-cover cover" style="background-color: {{ HEADER_COLOR }}">
         {% else %}
             <div class="post-cover cover" style="background-image: url('{{ SITEURL }}/{{ THEME_STATIC_DIR }}/images/post-bg.jpg')">
-        {% endif %}        
+        {% endif %}
       </div>
-    </header>    
+    </header>
 {% endblock header %}
 
 {% block content %}

--- a/templates/article.html
+++ b/templates/article.html
@@ -59,11 +59,11 @@
         <nav id="navigation">
           {% if SITE_LOGO %}
             <span class="blog-logo">
-                <a href="{{ SITEURL }}"><img src="{{SITE_LOGO}}" alt="Blog Logo" /></a>
+                <a href="{{ SITEURL }}/"><img src="{{SITE_LOGO}}" alt="Blog Logo" /></a>
             </span>
           {% else %}
             <span id="home-button" class="nav-button">
-                <a class="home-button" href="{{ SITEURL }}" title="Home"><i class="ic ic-arrow-left"></i> Home</a>
+                <a class="home-button" href="{{ SITEURL }}/" title="Home"><i class="ic ic-arrow-left"></i> Home</a>
             </span>
           {% endif %}
           <span id="menu-button" class="nav-button">
@@ -156,7 +156,7 @@
                     </div>
                     <div class="clear"></div>
                 </aside>
-                {% endif %} 
+                {% endif %}
                 {% endfor %}
 
                 </section>
@@ -172,14 +172,14 @@
                     {% endif %}
                     var disqus_url = '{{ SITEURL }}/{{ article.url }}';
                 </script>
-                <noscript>Please enable JavaScript to view the comments.</noscript>                  
+                <noscript>Please enable JavaScript to view the comments.</noscript>
                 <section class="post-comments">
                     {% if article.disqus_identifier %}
                         <a id="show-disqus" class="post-comments-activate" data-disqus-identifier="{{ article.disqus_identifier }}" >Show Comments</a>
                     {% else %}
                         <a id="show-disqus" class="post-comments-activate" data-disqus-identifier="/{{ article.url }}" >Show Comments</a>
                     {% endif %}
-                    <div id="disqus_thread"></div>                  
+                    <div id="disqus_thread"></div>
                 </section>
                 {% endif %}
 

--- a/templates/author.html
+++ b/templates/author.html
@@ -19,11 +19,11 @@
         <nav id="navigation">
           {% if SITE_LOGO %}
             <span class="blog-logo">
-                <a href="{{ SITEURL }}"><img src="{{SITE_LOGO}}" alt="Blog Logo" /></a>
+                <a href="{{ SITEURL }}/"><img src="{{SITE_LOGO}}" alt="Blog Logo" /></a>
             </span>
           {% else %}
             <span id="home-button" class="nav-button">
-                <a class="home-button" href="{{ SITEURL }}" title="Home"><i class="ic ic-arrow-left"></i> Home</a>
+                <a class="home-button" href="{{ SITEURL }}/" title="Home"><i class="ic ic-arrow-left"></i> Home</a>
             </span>
           {% endif %}
           <span id="menu-button" class="nav-button">
@@ -31,7 +31,7 @@
           </span>
         </nav>
         {% if HEADER_COVER %}
-            <div class="blog-cover cover" style="background-image: url('{{ HEADER_COVER }}')">            
+            <div class="blog-cover cover" style="background-image: url('{{ HEADER_COVER }}')">
         {% elif HEADER_COLOR %}
             <div class="post-cover cover" style="background-color: {{ HEADER_COLOR }}">
         {% else %}
@@ -72,6 +72,6 @@
             </aside>
         </div>
     </section>
-    {% endif %} 
+    {% endif %}
 
 {% endblock header %}

--- a/templates/authors.html
+++ b/templates/authors.html
@@ -14,7 +14,7 @@
             </span>
           {% else %}
             <span id="home-button" class="nav-button">
-                <a class="home-button" href="{{ SITEURL }}" title="Home"><i class="ic ic-arrow-left"></i> Home</a>
+                <a class="home-button" href="{{ SITEURL }}/" title="Home"><i class="ic ic-arrow-left"></i> Home</a>
             </span>
           {% endif %}
           <span id="menu-button" class="nav-button">
@@ -23,14 +23,14 @@
         </nav>
         <h1 class="post-title">Articles by {{ author|capitalize }}</h1>
         {% if HEADER_COVER %}
-            <div class="blog-cover cover" style="background-image: url('{{ HEADER_COVER }}')">            
+            <div class="blog-cover cover" style="background-image: url('{{ HEADER_COVER }}')">
         {% elif HEADER_COLOR %}
             <div class="post-cover cover" style="background-color: {{ HEADER_COLOR }}">
         {% else %}
             <div class="post-cover cover" style="background-image: url('{{ SITEURL }}/{{ THEME_STATIC_DIR }}/images/post-bg.jpg')">
-        {% endif %}        
+        {% endif %}
       </div>
-    </header>    
+    </header>
 {% endblock header %}
 
 {% block content %}

--- a/templates/authors.html
+++ b/templates/authors.html
@@ -10,7 +10,7 @@
         <nav id="navigation">
           {% if SITE_LOGO %}
             <span class="blog-logo">
-                <a href="{{ SITEURL }}"><img src="{{SITE_LOGO}}" alt="Blog Logo" /></a>
+                <a href="{{ SITEURL }}/"><img src="{{SITE_LOGO}}" alt="Blog Logo" /></a>
             </span>
           {% else %}
             <span id="home-button" class="nav-button">

--- a/templates/base.html
+++ b/templates/base.html
@@ -21,7 +21,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="referrer" content="origin" />
   <meta name="generator" content="Pelican" />
-  <link href="{{ SITEURL }}" rel="canonical" />
+  <link href="{{ SITEURL }}/" rel="canonical" />
 
   <!-- Feed -->
   {% for name,link in SOCIAL if name.lower() in ['rss', 'rss-square', 'feed'] %}

--- a/templates/categories.html
+++ b/templates/categories.html
@@ -10,11 +10,11 @@
         <nav id="navigation">
           {% if SITE_LOGO %}
             <span class="blog-logo">
-                <a href="{{ SITEURL }}"><img src="{{SITE_LOGO}}" alt="Blog Logo" /></a>
+                <a href="{{ SITEURL }}/"><img src="{{SITE_LOGO}}" alt="Blog Logo" /></a>
             </span>
           {% else %}
             <span id="home-button" class="nav-button">
-                <a class="home-button" href="{{ SITEURL }}" title="Home"><i class="ic ic-arrow-left"></i> Home</a>
+                <a class="home-button" href="{{ SITEURL }}/" title="Home"><i class="ic ic-arrow-left"></i> Home</a>
             </span>
           {% endif %}
           <span id="menu-button" class="nav-button">
@@ -23,14 +23,14 @@
         </nav>
         <h1 class="post-title">{{ SITENAME }} - Categories</h1>
         {% if HEADER_COVER %}
-            <div class="blog-cover cover" style="background-image: url('{{ HEADER_COVER }}')">            
+            <div class="blog-cover cover" style="background-image: url('{{ HEADER_COVER }}')">
         {% elif HEADER_COLOR %}
             <div class="post-cover cover" style="background-color: {{ HEADER_COLOR }}">
         {% else %}
             <div class="post-cover cover" style="background-image: url('{{ SITEURL }}/{{ THEME_STATIC_DIR }}/images/post-bg.jpg')">
-        {% endif %}        
+        {% endif %}
       </div>
-    </header>    
+    </header>
 {% endblock header %}
 
 {% block content %}

--- a/templates/category.html
+++ b/templates/category.html
@@ -14,7 +14,7 @@
             </span>
           {% else %}
             <span id="home-button" class="nav-button">
-                <a class="home-button" href="{{ SITEURL }}" title="Home"><i class="ic ic-arrow-left"></i> Home</a>
+                <a class="home-button" href="{{ SITEURL }}/" title="Home"><i class="ic ic-arrow-left"></i> Home</a>
             </span>
           {% endif %}
           <span id="menu-button" class="nav-button">

--- a/templates/category.html
+++ b/templates/category.html
@@ -10,7 +10,7 @@
         <nav id="navigation">
           {% if SITE_LOGO %}
             <span class="blog-logo">
-                <a href="{{ SITEURL }}"><img src="{{SITE_LOGO}}" alt="Blog Logo" /></a>
+                <a href="{{ SITEURL }}/"><img src="{{SITE_LOGO}}" alt="Blog Logo" /></a>
             </span>
           {% else %}
             <span id="home-button" class="nav-button">

--- a/templates/index.html
+++ b/templates/index.html
@@ -14,14 +14,14 @@
         <nav id="navigation">
           {% if SITE_LOGO %}
           <span class="blog-logo">
-            <a href="{{ SITEURL }}"><img src="{{SITE_LOGO}}" alt="Blog Logo" /></a>
+            <a href="{{ SITEURL }}/"><img src="{{SITE_LOGO}}" alt="Blog Logo" /></a>
           </span>
           {% endif %}
           <span id="menu-button" class="nav-button">
             <a class="menu-button"><i class="ic ic-menu"></i> Menu</a>
           </span>
         </nav>
-        <h1 class="blog-name"><a href="{{ SITEURL }}">{{ SITENAME }}</a></h1>
+        <h1 class="blog-name"><a href="{{ SITEURL }}/">{{ SITENAME }}</a></h1>
         {% if SITESUBTITLE %}
         <span class="blog-description">{{ SITESUBTITLE }}</span>
         {% endif %}

--- a/templates/page.html
+++ b/templates/page.html
@@ -31,7 +31,7 @@
             </span>
           {% else %}
             <span id="home-button" class="nav-button">
-                <a class="home-button" href="{{ SITEURL }}" title="Home"><i class="ic ic-arrow-left"></i> Home</a>
+                <a class="home-button" href="{{ SITEURL }}/" title="Home"><i class="ic ic-arrow-left"></i> Home</a>
             </span>
           {% endif %}
           <span id="menu-button" class="nav-button">

--- a/templates/page.html
+++ b/templates/page.html
@@ -27,7 +27,7 @@
         <nav id="navigation">
           {% if SITE_LOGO %}
             <span class="blog-logo">
-                <a href="{{ SITEURL }}"><img src="{{SITE_LOGO}}" alt="Blog Logo" /></a>
+                <a href="{{ SITEURL }}/"><img src="{{SITE_LOGO}}" alt="Blog Logo" /></a>
             </span>
           {% else %}
             <span id="home-button" class="nav-button">

--- a/templates/partials/jsonld.html
+++ b/templates/partials/jsonld.html
@@ -16,7 +16,7 @@
   "@context" : "http://schema.org",
   "@type" : "Website",
   "name": " {{ SITENAME }} ",
-  "url" : "{{ SITEURL }}",
+  "url" : "{{ SITEURL }}/",
   "image": "{{ default_cover }}",
   "description": "{{ description }}"
 }

--- a/templates/partials/og.html
+++ b/templates/partials/og.html
@@ -28,7 +28,7 @@
 <meta property="og:title" content="{{ SITENAME }}"/>
 <meta property="og:description" content="{{ description }}"/>
 <meta property="og:locale" content="{{ default_locale }}"/>
-<meta property="og:url" content="{{ SITEURL }}"/>
+<meta property="og:url" content="{{ SITEURL }}/"/>
 <meta property="og:image" content="{{ default_cover }}">
 
 <!-- Twitter Card -->
@@ -37,6 +37,6 @@
   <meta name="twitter:site" content="@{{ link|replace('http://', 'https://')|replace('https://twitter.com/', '') }}">
   <meta name="twitter:title" content="{{ SITENAME }}">
   <meta name="twitter:description" content="{{ description}}">
-  <meta name="twitter:url" content="{{ SITEURL }}">
+  <meta name="twitter:url" content="{{ SITEURL }}/">
   <meta name="twitter:image:src" content="{{ default_cover }}">
 {% endfor %}

--- a/templates/period_archives.html
+++ b/templates/period_archives.html
@@ -14,7 +14,7 @@
             </span>
           {% else %}
             <span id="home-button" class="nav-button">
-                <a class="home-button" href="{{ SITEURL }}" title="Home"><i class="ic ic-arrow-left"></i> Home</a>
+                <a class="home-button" href="{{ SITEURL }}/" title="Home"><i class="ic ic-arrow-left"></i> Home</a>
             </span>
           {% endif %}
           <span id="menu-button" class="nav-button">

--- a/templates/period_archives.html
+++ b/templates/period_archives.html
@@ -10,7 +10,7 @@
         <nav id="navigation">
           {% if SITE_LOGO %}
             <span class="blog-logo">
-                <a href="{{ SITEURL }}"><img src="{{SITE_LOGO}}" alt="Blog Logo" /></a>
+                <a href="{{ SITEURL }}/"><img src="{{SITE_LOGO}}" alt="Blog Logo" /></a>
             </span>
           {% else %}
             <span id="home-button" class="nav-button">

--- a/templates/tag.html
+++ b/templates/tag.html
@@ -9,7 +9,7 @@
         <nav id="navigation">
           {% if SITE_LOGO %}
             <span class="blog-logo">
-                <a href="{{ SITEURL }}"><img src="{{SITE_LOGO}}" alt="Blog Logo" /></a>
+                <a href="{{ SITEURL }}/"><img src="{{SITE_LOGO}}" alt="Blog Logo" /></a>
             </span>
           {% else %}
             <span id="home-button" class="nav-button">

--- a/templates/tag.html
+++ b/templates/tag.html
@@ -13,7 +13,7 @@
             </span>
           {% else %}
             <span id="home-button" class="nav-button">
-                <a class="home-button" href="{{ SITEURL }}" title="Home"><i class="ic ic-arrow-left"></i> Home</a>
+                <a class="home-button" href="{{ SITEURL }}/" title="Home"><i class="ic ic-arrow-left"></i> Home</a>
             </span>
           {% endif %}
           <span id="menu-button" class="nav-button">

--- a/templates/tags.html
+++ b/templates/tags.html
@@ -14,7 +14,7 @@
             </span>
           {% else %}
             <span id="home-button" class="nav-button">
-                <a class="home-button" href="{{ SITEURL }}" title="Home"><i class="ic ic-arrow-left"></i> Home</a>
+                <a class="home-button" href="{{ SITEURL }}/" title="Home"><i class="ic ic-arrow-left"></i> Home</a>
             </span>
           {% endif %}
           <span id="menu-button" class="nav-button">

--- a/templates/tags.html
+++ b/templates/tags.html
@@ -10,7 +10,7 @@
         <nav id="navigation">
           {% if SITE_LOGO %}
             <span class="blog-logo">
-                <a href="{{ SITEURL }}"><img src="{{SITE_LOGO}}" alt="Blog Logo" /></a>
+                <a href="{{ SITEURL }}/"><img src="{{SITE_LOGO}}" alt="Blog Logo" /></a>
             </span>
           {% else %}
             <span id="home-button" class="nav-button">


### PR DESCRIPTION
Pelican is dependent on the theme to add in trailing slashes. Since Attila was not adding "/" and my local SITEURL was `''` the home URL did not redirect properly and remained on the same page. Now it will properly redirect to the index page.

Related issue for additional context: https://github.com/getpelican/pelican/issues/1156