### PR TITLE
Implement AUTHOR_BIO "name" and "cover" fields.

### DIFF
--- a/templates/article.html
+++ b/templates/article.html
@@ -83,7 +83,11 @@
         {% endif %}
         <span class="post-meta">
             {% for author in article.authors %}
-                <a href="{{ SITEURL }}/{{ author.url }}">{{ author|title }}</a>
+                {% set author_name = author.name | title %}
+                {% if AUTHORS_BIO and author.name.lower() in AUTHORS_BIO %}
+                    {% set author_name = AUTHORS_BIO[author.name.lower()].name or author.name %}
+                {% endif %}
+                <a href="{{ SITEURL }}/{{ author.url }}">{{ author_name }}</a>
             {% endfor %}
             | <time datetime="{{ article.locale_date }}">{{ article.locale_date }}</time>
         </span>

--- a/templates/article.html
+++ b/templates/article.html
@@ -137,21 +137,20 @@
                 {% for author in article.authors %}
                 {% if AUTHORS_BIO and author.name.lower() in AUTHORS_BIO %}
                 <aside class="post-author">
+                    {% set author_name = AUTHORS_BIO[author.name.lower()].name or author.name %}
                     {% set author_avatar = AUTHORS_BIO[author.name.lower()].image %}
                     {% if  author_avatar %}
 
-                        {% if author_avatar|lower|truncate(4, True, '') == "http" %}
-                            {% set author_avatar = author_avatar %}
-                        {% else %}
+                        {% if author_avatar|lower|truncate(4, True, '') != "http" %}
                             {% set author_avatar = SITEURL+"/"+author_avatar %}
                         {% endif %}
 
                         <figure class="post-author-avatar">
-                            <img src="{{author_avatar}}" alt="{{author.name | title}}" />
+                            <img src="{{author_avatar}}" alt="{{author_name}}" />
                         </figure>
                     {% endif %}
                     <div class="post-author-bio">
-                        <h4 class="post-author-name"><a href="{{ SITEURL }}/{{author.url}}">{{author.name | title}}</a></h4>
+                        <h4 class="post-author-name"><a href="{{ SITEURL }}/{{author.url}}">{{author_name}}</a></h4>
                         {% if AUTHORS_BIO[author.name.lower()].bio %}
                             <p class="post-author-about">{{AUTHORS_BIO[author.name.lower()].bio}}</p>
                         {% endif %}

--- a/templates/author.html
+++ b/templates/author.html
@@ -1,7 +1,5 @@
 {% extends "index.html" %}
 
-{% block title %}{{ SITENAME }} - Articles by {{ author }}{% endblock %}
-
 <!-- To support both image in relative path and url  -->
 {% if AUTHORS_BIO and author.name.lower() in AUTHORS_BIO %}
     {% set author_avatar = AUTHORS_BIO[author.name.lower()].image %}
@@ -20,6 +18,8 @@
 
     {% set author_name = AUTHORS_BIO[author.name.lower()].name or author.name %}
 {% endif %}
+
+{% block title %}{{ SITENAME }} - Articles by {{ author_name }}{% endblock %}
 
 {% block opengraph %}
     {{ super() }}

--- a/templates/author.html
+++ b/templates/author.html
@@ -5,13 +5,20 @@
 <!-- To support both image in relative path and url  -->
 {% if AUTHORS_BIO and author.name.lower() in AUTHORS_BIO %}
     {% set author_avatar = AUTHORS_BIO[author.name.lower()].image %}
-    {% if  author_avatar %}
-        {% if author_avatar|lower|truncate(4, True, '') == "http" %}
-            {% set author_avatar = author_avatar %}
-        {% else %}
+    {% if author_avatar %}
+        {% if author_avatar|lower|truncate(4, True, '') != "http" %}
             {% set author_avatar = SITEURL+"/"+author_avatar %}
         {% endif %}
     {% endif %}
+
+    {% set author_cover = AUTHORS_BIO[author.name.lower()].cover %}
+    {% if author_cover %}
+        {% if author_cover|lower|truncate(4, True, '') != "http" %}
+            {% set author_cover= SITEURL+"/"+author_cover %}
+        {% endif %}
+    {% endif %}
+
+    {% set author_name = AUTHORS_BIO[author.name.lower()].name or author.name %}
 {% endif %}
 
 {% block opengraph %}
@@ -42,10 +49,8 @@
             <a class="menu-button"><i class="ic ic-menu"></i> Menu</a>
           </span>
         </nav>
-        {% if AUTHORS_BIO and author.name.lower() in AUTHORS_BIO %}
-        {% if author_avatar %}
-            <div class="blog-cover cover" style="background-image: url('{{ author_avatar }}')">
-        {% endif %}
+        {% if AUTHORS_BIO and author.name.lower() in AUTHORS_BIO and author_cover %}
+            <div class="blog-cover cover" style="background-image: url('{{ author_cover }}')">
         {% elif HEADER_COVER %}
             <div class="blog-cover cover" style="background-image: url('{{ HEADER_COVER }}')">
         {% elif HEADER_COLOR %}
@@ -62,11 +67,11 @@
             <aside class="post-author">
                 {% if author_avatar %}
                 <figure class="post-author-avatar">
-                    <img src="{{author_avatar}}" alt="{{author.name | title}}" />
+                    <img src="{{author_avatar}}" alt="{{author_name}}" />
                 </figure>
                 {% endif %}
                 <div class="post-author-bio">
-                    <h4 class="post-author-name"><a href="{{ SITEURL }}/{{author.url}}">{{author.name | title}}</a></h4>
+                    <h4 class="post-author-name"><a href="{{ SITEURL }}/{{author.url}}">{{author_name}}</a></h4>
                     {% if AUTHORS_BIO[author.name.lower()].bio %}
                         <p class="post-author-about">{{AUTHORS_BIO[author.name.lower()].bio}}</p>
                     {% endif %}

--- a/templates/author.html
+++ b/templates/author.html
@@ -1,6 +1,7 @@
 {% extends "index.html" %}
 
 <!-- To support both image in relative path and url  -->
+{% set author_name = author.name | title  %}
 {% if AUTHORS_BIO and author.name.lower() in AUTHORS_BIO %}
     {% set author_avatar = AUTHORS_BIO[author.name.lower()].image %}
     {% if author_avatar %}

--- a/templates/authors.html
+++ b/templates/authors.html
@@ -21,7 +21,7 @@
             <a class="menu-button"><i class="ic ic-menu"></i> Menu</a>
           </span>
         </nav>
-        <h1 class="post-title">Articles by {{ author|title }}</h1>
+        <h1 class="post-title">{{ SITENAME }} - Authors</h1>
         {% if HEADER_COVER %}
             <div class="blog-cover cover" style="background-image: url('{{ HEADER_COVER }}')">
         {% elif HEADER_COLOR %}
@@ -35,11 +35,16 @@
 
 {% block content %}
     {% for author, articles in authors|sort %}
+        {% set author_name = author.name | title  %}
+        {% if AUTHORS_BIO and author.name.lower() in AUTHORS_BIO %}
+            {% set author_name = AUTHORS_BIO[author.name.lower()].name or author.name %}
+        {% endif %}
+
       <article class="post">
         <div class="inner">
             <a href="{{ SITEURL }}/{{ author.url }}" rel="bookmark">
                 <h2 class="post-title">
-                    {{ author }} ({{ articles|count }})
+                    {{ author_name }} ({{ articles|count }})
                 </h2>
             </a>
         </div>

--- a/templates/partials/loop.html
+++ b/templates/partials/loop.html
@@ -5,11 +5,12 @@
     {% for article in articles_page.object_list %}
         <article class="post">
         <div class="inner">
-            <header class="post-header">         
+            <header class="post-header">
                 <h2 class="post-title"><a href="{{ SITEURL }}/{{ article.url }}" rel="bookmark" title="Permalink to {{ article.title|striptags }}">{{ article.title }}</a>
                 </h2>
                 <span class="post-meta">
                     {% for author in article.authors %}
+                        {% set author_name = author.name | title %}
                         {% if AUTHORS_BIO and author.name.lower() in AUTHORS_BIO %}
                             {% set author_name = AUTHORS_BIO[author.name.lower()].name or author.name %}
                         {% endif %}

--- a/templates/partials/loop.html
+++ b/templates/partials/loop.html
@@ -10,7 +10,10 @@
                 </h2>
                 <span class="post-meta">
                     {% for author in article.authors %}
-                        <a href="{{ SITEURL }}/{{ author.url }}">{{ author|title }}</a>
+                        {% if AUTHORS_BIO and author.name.lower() in AUTHORS_BIO %}
+                            {% set author_name = AUTHORS_BIO[author.name.lower()].name or author.name %}
+                        {% endif %}
+                        <a href="{{ SITEURL }}/{{ author.url }}">{{ author_name }}</a>
                     {% endfor %}
                      | <time datetime="{{ article.locale_date }}">{{ article.locale_date }}</time>
                 </span>


### PR DESCRIPTION
In the theme readme, there's are "name" and "cover" fields in the
AUTHOR_BIO example, but these two fields weren't implemented yet.

Instead, the author page was displaying the author entry through
the title Jinja2 filter (which doesn't work so well for surnames like
mine, which contains multiple capital letters ;) ), and the cover
image was being used for the avatar image. This change uses the
"name" and "cover" fields for these, respectfully.

The cover image on the author page will also gracefully fall back
to the site default if an author cover isn't specified as well.