### PR TITLE
Modified author headers to show fullname

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -167,7 +167,7 @@ JS_OVERRIDE = ['']
 ....
 AUTHORS_BIO = {
   "zutrinken": {
-    "name": "Zutrinken",
+    "fullname": "Zutrinken",
     "cover": "https://arulrajnet.github.io/attila-demo/assets/images/avatar.png",
     "image": "https://arulrajnet.github.io/attila-demo/assets/images/avatar.png",
     "website": "http://blog.arulraj.net",

--- a/templates/article.html
+++ b/templates/article.html
@@ -151,7 +151,11 @@
                         </figure>
                     {% endif %}
                     <div class="post-author-bio">
+                      {%if AUTHORS_BIO[author.name.lower()].bio %}
+                        <h4 class="post-author-name"><a href="{{ SITEURL }}/{{author.url}}">{{AUTHORS_BIO[author.name.lower()].fullname | title}}</a></h4>
+                      {% else %}
                         <h4 class="post-author-name"><a href="{{ SITEURL }}/{{author.url}}">{{author.name | title}}</a></h4>
+                      {% endif %}
                         {% if AUTHORS_BIO[author.name.lower()].bio %}
                             <p class="post-author-about">{{AUTHORS_BIO[author.name.lower()].bio}}</p>
                         {% endif %}

--- a/templates/author.html
+++ b/templates/author.html
@@ -66,7 +66,11 @@
                 </figure>
                 {% endif %}
                 <div class="post-author-bio">
-                    <h4 class="post-author-name"><a href="{{ SITEURL }}/{{author.url}}">{{author.name | title}}</a></h4>
+                    {%if AUTHORS_BIO[author.name.lower()].bio %}
+                      <h4 class="post-author-name"><a href="{{ SITEURL }}/{{author.url}}">{{AUTHORS_BIO[author.name.lower()].fullname | title}}</a></h4>
+                    {% else %}
+                      <h4 class="post-author-name"><a href="{{ SITEURL }}/{{author.url}}">{{author.name | title}}</a></h4>
+                    {% endif %}
                     {% if AUTHORS_BIO[author.name.lower()].bio %}
                         <p class="post-author-about">{{AUTHORS_BIO[author.name.lower()].bio}}</p>
                     {% endif %}


### PR DESCRIPTION
A summary of changes made : 
* Changed `name` to `fullname` in the author configuration because `name` is an ambiguous variable and can be confused with the `name` in the author object of Pelican.
* Show the `fullname` in author and the post sections instead of the user slug.
* Added backwards compatibilty with an if-else block.
* Changed README to reflect change in template.

