### PR TITLE
Custom headers

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -86,6 +86,21 @@ This is site level cover image and it will be used If there is no cover
 image set in link:#articles[article] level.
 
 [[header-color]]
+
+==== Custom Header Covers
+
+For each page, category page, tag page or author page you can set a custom header cover.
+To define it, just set the following properties in `pelicanconf.py`
+
+Use the page title as defined in metadata for the pages
+
+----
+HEADER_COVERS_BY_TAG = {'food': '/images/food.png', 'drinks':'/images/orange-juice.png'}
+HEADER_COVERS_BY_PAGE= {'Hello': '/images/selfie.png'}
+HEADER_COVERS_BY_CATEGORY = {'food': '/images/junkie-stuff.png'}
+---
+
+
 === Header Color
 
 To define a simple header background color, set the property

--- a/README.adoc
+++ b/README.adoc
@@ -94,6 +94,7 @@ To define it, just set the following properties in `pelicanconf.py`
 
 Use the page title as defined in metadata for the pages
 
+[source,python]
 ----
 HEADER_COVERS_BY_TAG = {'food': '/images/food.png', 'drinks':'/images/orange-juice.png'}
 HEADER_COVERS_BY_PAGE= {'Hello': '/images/selfie.png'}

--- a/README.adoc
+++ b/README.adoc
@@ -99,7 +99,7 @@ Use the page title as defined in metadata for the pages
 HEADER_COVERS_BY_TAG = {'food': '/images/food.png', 'drinks':'/images/orange-juice.png'}
 HEADER_COVERS_BY_PAGE= {'Hello': '/images/selfie.png'}
 HEADER_COVERS_BY_CATEGORY = {'food': '/images/junkie-stuff.png'}
----
+----
 
 
 === Header Color

--- a/README.adoc
+++ b/README.adoc
@@ -97,7 +97,6 @@ Use the page title as defined in metadata for the pages
 [source,python]
 ----
 HEADER_COVERS_BY_TAG = {'food': '/images/food.png', 'drinks':'/images/orange-juice.png'}
-HEADER_COVERS_BY_PAGE= {'Hello': '/images/selfie.png'}
 HEADER_COVERS_BY_CATEGORY = {'food': '/images/junkie-stuff.png'}
 ----
 

--- a/templates/category.html
+++ b/templates/category.html
@@ -23,7 +23,9 @@
         </nav>
         <h1 class="post-title">Category {{ category }}</h1>
         <span class="blog-description">Posts: {{ articles|count }}</span>
-        {% if HEADER_COVER %}
+        {% if category in HEADER_COVERS_BY_CATEGORY %}
+            <div class="blog-cover cover" style="background-image: url('{{ HEADER_COVERS_BY_CATEGORY.get(category) }}')">
+        {% elif HEADER_COVER %}
             <div class="blog-cover cover" style="background-image: url('{{ HEADER_COVER }}')">            
         {% elif HEADER_COLOR %}
             <div class="post-cover cover" style="background-color: {{ HEADER_COLOR }}">

--- a/templates/page.html
+++ b/templates/page.html
@@ -39,7 +39,9 @@
           </span>
         </nav>
         <h1 class="post-title">{{ page.title }}</h1>
-        {% if default_cover %}
+        {% if page.title in HEADER_COVERS_BY_PAGE %}
+            <div class="blog-cover cover" style="background-image: url('{{ HEADER_COVERS_BY_PAGE.get(page.title) }}')">
+        {% elif default_cover %}
             <div class="post-cover cover" style="background-image: url('{{ default_cover }}')">
         {% elif HEADER_COLOR %}
             <div class="post-cover cover" style="background-color: {{ HEADER_COLOR }}">

--- a/templates/page.html
+++ b/templates/page.html
@@ -39,9 +39,7 @@
           </span>
         </nav>
         <h1 class="post-title">{{ page.title }}</h1>
-        {% if page.title in HEADER_COVERS_BY_PAGE %}
-            <div class="blog-cover cover" style="background-image: url('{{ HEADER_COVERS_BY_PAGE.get(page.title) }}')">
-        {% elif default_cover %}
+        {% if default_cover %}
             <div class="post-cover cover" style="background-image: url('{{ default_cover }}')">
         {% elif HEADER_COLOR %}
             <div class="post-cover cover" style="background-color: {{ HEADER_COLOR }}">

--- a/templates/tag.html
+++ b/templates/tag.html
@@ -22,7 +22,9 @@
         </nav>
         <h1 class="post-title">Tag {{ tag }}</h1>
         <span class="blog-description">Posts: {{ articles|count }}</span>
-        {% if HEADER_COVER %}
+        {% if tag in HEADER_COVERS_BY_TAG %}
+            <div class="blog-cover cover" style="background-image: url('{{ HEADER_COVERS_BY_TAG.get(tag) }}')">
+        {% elif HEADER_COVER %}
             <div class="blog-cover cover" style="background-image: url('{{ HEADER_COVER }}')">            
         {% elif HEADER_COLOR %}
             <div class="post-cover cover" style="background-color: {{ HEADER_COLOR }}">


### PR DESCRIPTION
I put the code to have custom header image for each page, each tag and each category. I also updated to Readme to document the differences, hope it's ok for you!

In case there is no tag, category or page specified in pelicanconf.py the theme should fall back on the default image.