### PR TITLE
Fix variable name in page template

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -21,8 +21,8 @@
   {% else %}
     {% set selected_cover = SITEURL+"/"+HEADER_COVER %}
   {% endif %}
-{% elif article.color %}
-  {% set selected_color = article.color %}
+{% elif page.color %}
+  {% set selected_color = page.color %}
 {% elif HEADER_COLOR %}
   {% set selected_color = HEADER_COLOR %}
 {% endif %}


### PR DESCRIPTION
The variable was incorrectly pasted as `article` which made rendering
pages impossible. Thanks to @kloppen for triaging and suggesting the fix.

Fixes #29