### PR TITLE
Google analytics update

### DIFF
--- a/templates/partials/analytics.js
+++ b/templates/partials/analytics.js
@@ -1,13 +1,11 @@
 {% if GOOGLE_ANALYTICS %}
-    <script type="text/javascript">
-    var _gaq = _gaq || [];
-    _gaq.push(['_setAccount', '{{GOOGLE_ANALYTICS}}']);
-    _gaq.push(['_trackPageview']);
-    (function() {
-        var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-        ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-    })();
+    <!-- Global Site Tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{GOOGLE_ANALYTICS}}"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', '{{GOOGLE_ANALYTICS}}');
     </script>
 {% endif %}
 {% if GAUGES %}

--- a/templates/partials/analytics.js
+++ b/templates/partials/analytics.js
@@ -5,7 +5,7 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', '{{GOOGLE_ANALYTICS}}');
+        gtag('config', '{{GOOGLE_ANALYTICS}}', { 'anonymize_ip': true });
     </script>
 {% endif %}
 {% if GAUGES %}


### PR DESCRIPTION
Previous template was using ga.js which is considered legacy now. The
recommended way to enable Google Analytics now is via gtag.js:
https://support.google.com/analytics/answer/1008080