### PR TITLE
Fix responsive layout for Archives page

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -641,6 +641,8 @@ dl {
 dl dt {
     float: left;
     width: 180px;
+    max-width: 30%;
+    margin-right: 1.5em;
     overflow: hidden;
     clear: left;
     text-align: right;
@@ -651,8 +653,16 @@ dl dt {
 }
 
 dl dd {
-    margin-left: 200px;
+    float: left;
+    max-width: calc(100% - 30% - 1.5em);
+    margin-left: 0;
     margin-bottom: 12px
+}
+
+dl:after, dl dd:after {
+    clear: both;
+    content: "";
+    display: block;
 }
 
 mark {


### PR DESCRIPTION
Previously the width of date field was hardcoded at 180px and that would take up most of screen estate on mobile devices. The most important part - article titles - may become condensed and even unreadable