### PR TITLE
update for pelican 4

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -40,16 +40,16 @@
           <link href="{{ FEED_DOMAIN }}/{{ FEED_RSS }}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} RSS Feed" />
       {% endif %}
       {% if CATEGORY_FEED_ATOM and category %}
-          <link href="{{ FEED_DOMAIN }}/{{ CATEGORY_FEED_ATOM|format(category.slug) }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Categories Atom Feed" />
+          <link href="{{ FEED_DOMAIN }}/{{ CATEGORY_FEED_ATOM|format(slug=category.slug) }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Categories Atom Feed" />
       {% endif %}
       {% if CATEGORY_FEED_RSS and category %}
-          <link href="{{ FEED_DOMAIN }}/{{ CATEGORY_FEED_RSS|format(category.slug) }}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} Categories RSS Feed" />
+          <link href="{{ FEED_DOMAIN }}/{{ CATEGORY_FEED_RSS|format(slug=category.slug) }}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} Categories RSS Feed" />
       {% endif %}
       {% if TAG_FEED_ATOM and tag %}
-          <link href="{{ FEED_DOMAIN }}/{{ TAG_FEED_ATOM|format(tag.slug) }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Tags Atom Feed" />
+          <link href="{{ FEED_DOMAIN }}/{{ TAG_FEED_ATOM|format(slug=tag.slug) }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Tags Atom Feed" />
       {% endif %}
       {% if TAG_FEED_RSS and tag %}
-          <link href="{{ FEED_DOMAIN }}/{{ TAG_FEED_RSS|format(tag.slug) }}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} Tags RSS Feed" />
+          <link href="{{ FEED_DOMAIN }}/{{ TAG_FEED_RSS|format(slug=tag.slug) }}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} Tags RSS Feed" />
       {% endif %}
   {% endfor %}
 


### PR DESCRIPTION
Hi,

According to [pelican's doc](http://docs.getpelican.com/en/stable/changelog.html#id1):
> If upgrading from 3.7.x or earlier, please note that slug-related settings in 4.0+ use {slug} and/or {lang} rather than %s. If %s-style settings are encountered, Pelican will emit a warning and fall back to the default setting. Some user-submitted themes might try to format setting values but fail upon site build with a TypeError. In such cases, the theme needs to be updated. For example, instead of TAG_FEED_ATOM|format(tag.slug), use TAG_FEED_ATOM|format(slug=tag.slug)

This fixed build in my case.