### PR TITLE
Revert changes to header id for blog posts

### DIFF
--- a/templates/article.html
+++ b/templates/article.html
@@ -63,7 +63,7 @@
 
     <!-- Page Header -->
     <!-- Set your background image for this header on the line below. -->
-    <header id="blog-header" {% if selected_cover or selected_color %}class="has-cover"{% endif %}>
+    <header id="post-header" {% if selected_cover or selected_color %}class="has-cover"{% endif %}>
       <div class="inner">
         <nav id="navigation">
           {% if SITE_LOGO %}


### PR DESCRIPTION
I believe the header id for blog posts was changed accidentally in e7a78c4ff7b5e79c57a988b824424577dbc66256. This pull request reverts that.

Current header id leads to incorrect rendering of blog headers:
- we get this 
![incorrect rendering](https://user-images.githubusercontent.com/334908/62196962-aca59380-b387-11e9-8655-fb1270d92fc1.png)

- instead of expected 
![correct rendering](https://user-images.githubusercontent.com/334908/62197014-c050fa00-b387-11e9-9988-c3dfafd49f65.png)
