### PR TITLE
Proper handling of canonical URLs

### DIFF
--- a/templates/article.html
+++ b/templates/article.html
@@ -30,7 +30,7 @@
 {% block head %}
   {{ super() }}
 
-  <link href="{{ SITEURL }}/{{ article.url }}" rel="canonical" />
+  {% block canonical_url %}<link href="{{ SITEURL }}/{{ article.url }}" rel="canonical" />{% endblock canonical_url %}
   {% for keyword in article.keywords %}
     <meta name="keywords" content="{{keyword}}" >
   {% endfor %}

--- a/templates/article.html
+++ b/templates/article.html
@@ -27,10 +27,10 @@
   {% set selected_color = HEADER_COLOR %}
 {% endif %}
 
+{% block canonical_url %}<link href="{{ SITEURL }}/{{ article.url }}" rel="canonical" />{% endblock canonical_url %}
 {% block head %}
   {{ super() }}
 
-  {% block canonical_url %}<link href="{{ SITEURL }}/{{ article.url }}" rel="canonical" />{% endblock canonical_url %}
   {% for keyword in article.keywords %}
     <meta name="keywords" content="{{keyword}}" >
   {% endfor %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -21,7 +21,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="referrer" content="origin" />
   <meta name="generator" content="Pelican" />
-  <link href="{{ SITEURL }}/" rel="canonical" />
+  {% block canonical_url %}<link href="{{ SITEURL }}/" rel="canonical" />{% endblock canonical_url %}
 
   <!-- Feed -->
   {% for name,link in SOCIAL if name.lower() in ['rss', 'rss-square', 'feed'] %}

--- a/templates/page.html
+++ b/templates/page.html
@@ -2,6 +2,10 @@
 
 {% block title %}{{ page.title }}{% endblock title %}
 
+{% block canonical_url %}
+<link href="{{ SITEURL }}/{{ page.url }}" rel="canonical" />
+{% endblock canonical_url %}
+
 {# <!-- Choosing cover image --> #}
 {% if page.cover %}
   {% if page.cover|lower|truncate(4, True, '') == "http" %}


### PR DESCRIPTION
Previously canonical URLs were badly broken: pages would not get any value and articles would receive two contradicting entries (one for site root, one for the article itself). Search engines do not like that.

Thanks to @QuantumGhost this can be fixed. I've cherry-picked relevant commit from their repo and modified it slightly to fix remaining duplicate values.