### PR TITLE
Add Open Graph support for Linkedin

### DIFF
--- a/templates/partials/og.html
+++ b/templates/partials/og.html
@@ -23,13 +23,13 @@
 {% for admin in FACEBOOK_ADMINS %}
   <meta property="fb:admins" content="{{ admin }}" />
 {% endfor %}
-<meta property="og:site_name" content="{{ SITENAME }}"/>
-<meta property="og:type" content="blog"/>
-<meta property="og:title" content="{{ SITENAME }}"/>
-<meta property="og:description" content="{{ description }}"/>
-<meta property="og:locale" content="{{ default_locale }}"/>
-<meta property="og:url" content="{{ SITEURL }}/"/>
-<meta property="og:image" content="{{ default_cover }}">
+<meta prefix="og: http://ogp.me/ns#" property="og:site_name" content="{{ SITENAME }}"/>
+<meta prefix="og: http://ogp.me/ns#" property="og:type" content="blog"/>
+<meta prefix="og: http://ogp.me/ns#" property="og:title" content="{{ SITENAME }}"/>
+<meta prefix="og: http://ogp.me/ns#" property="og:description" content="{{ description }}"/>
+<meta prefix="og: http://ogp.me/ns#" property="og:locale" content="{{ default_locale }}"/>
+<meta prefix="og: http://ogp.me/ns#" property="og:url" content="{{ SITEURL }}/"/>
+<meta prefix="og: http://ogp.me/ns#" property="og:image" content="{{ default_cover }}">
 
 <!-- Twitter Card -->
 {% for name,link in SOCIAL if name.lower() in ['twitter'] %}

--- a/templates/partials/og_article.html
+++ b/templates/partials/og_article.html
@@ -35,23 +35,23 @@
 {% for admin in FACEBOOK_ADMINS %}
   <meta property="fb:admins" content="{{ admin }}" />
 {% endfor %}
-<meta property="og:site_name" content="{{ SITENAME }}"/>
-<meta property="og:title" content="{{ article.title|striptags }}"/>
-<meta property="og:description" content="{{ description }}"/>
-<meta property="og:locale" content="{{ article.metadata.get('og_locale', default_locale) }}"/>
-<meta property="og:url" content="{{ SITEURL }}/{{ article.url }}"/>
-<meta property="og:type" content="article"/>
-<meta property="article:published_time" content="{{ article.date }}"/>
-<meta property="article:modified_time" content="{{ article.modified }}"/>
-<meta property="article:author" content="{{ SITEURL }}/{{ article.author.url }}">
+<meta prefix="og: http://ogp.me/ns#" property="og:site_name" content="{{ SITENAME }}"/>
+<meta prefix="og: http://ogp.me/ns#" property="og:title" content="{{ article.title|striptags }}"/>
+<meta prefix="og: http://ogp.me/ns#" property="og:description" content="{{ description }}"/>
+<meta prefix="og: http://ogp.me/ns#" property="og:locale" content="{{ article.metadata.get('og_locale', default_locale) }}"/>
+<meta prefix="og: http://ogp.me/ns#" property="og:url" content="{{ SITEURL }}/{{ article.url }}"/>
+<meta prefix="og: http://ogp.me/ns#" property="og:type" content="article"/>
+<meta prefix="og: http://ogp.me/ns#" property="article:published_time" content="{{ article.date }}"/>
+<meta prefix="og: http://ogp.me/ns#" property="article:modified_time" content="{{ article.modified }}"/>
+<meta prefix="og: http://ogp.me/ns#" property="article:author" content="{{ SITEURL }}/{{ article.author.url }}">
 {% for name,link in SOCIAL if name.lower() in ['facebook'] %}
-  <meta property="article:publisher" content="{{ link }}" />
+  <meta prefix="og: http://ogp.me/ns#" property="article:publisher" content="{{ link }}" />
 {% endfor %}
-<meta property="article:section" content="{{ article.category.name }}"/>
+<meta prefix="og: http://ogp.me/ns#" property="article:section" content="{{ article.category.name }}"/>
 {% for tag in article.tags %}
-<meta property="article:tag" content="{{ tag.name }}"/>
+<meta prefix="og: http://ogp.me/ns#" property="article:tag" content="{{ tag.name }}"/>
 {% endfor %}
-<meta property="og:image" content="{{ default_cover }}">
+<meta prefix="og: http://ogp.me/ns#" property="og:image" content="{{ default_cover }}">
 
 <!-- Twitter Card -->
 {% for name,link in SOCIAL if name.lower() in ['twitter'] %}


### PR DESCRIPTION
Linked in requires the 'prefix="og: http://ogp.me/ns#"' to work correctly for links posted to Linkedin