### PR TITLE
Allow to left out google fonts

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -76,8 +76,8 @@
     {% endfor %}
   {% endif %}
 
-  <!-- Custom fonts -->
   {% if ALLOW_GOOGLE_FONTS %}
+    <!-- Custom fonts -->
     <link href='https://fonts.googleapis.com/css?family=Montserrat:400,300' rel='stylesheet' type='text/css' />
     <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet" type="text/css" />
   {% endif %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -77,8 +77,10 @@
   {% endif %}
 
   <!-- Custom fonts -->
-  <link href='https://fonts.googleapis.com/css?family=Montserrat:400,300' rel='stylesheet' type='text/css' />
-  <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet" type="text/css" />
+  {% if ALLOW_GOOGLE_FONTS %}
+    <link href='https://fonts.googleapis.com/css?family=Montserrat:400,300' rel='stylesheet' type='text/css' />
+    <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet" type="text/css" />
+  {% endif %}
 
   <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->


### PR DESCRIPTION
In germany it is not allowed anymore to use google fonts dynamicly as for the DSGVO. To reflect this into the theme I added the possibility to add "ALLOW_GOOGLE_FONTS = False" into the publishconf.py