### PR TITLE
Correct Canonicals

### DIFF
--- a/templates/authors.html
+++ b/templates/authors.html
@@ -18,7 +18,7 @@
   {% set selected_color = HEADER_COLOR %}
 {% endif %}
 
-{% block canonical_url %}<link href="{{ SITEURL }}/authors" rel="canonical" />{% endblock canonical_url %}
+{% block canonical_url %}<link href="{{ SITEURL }}/{{ AUTHORS_SAVE_AS }}" rel="canonical" />{% endblock canonical_url %}
 
 {% block header %}
     <!-- Page Header -->

--- a/templates/categories.html
+++ b/templates/categories.html
@@ -18,7 +18,7 @@
   {% set selected_color = HEADER_COLOR %}
 {% endif %}
 
-{% block canonical_url %}<link href="{{ SITEURL }}/categories" rel="canonical" />{% endblock canonical_url %}
+{% block canonical_url %}<link href="{{ SITEURL }}/{{ CATEGORIES_SAVE_AS }}" rel="canonical" />{% endblock canonical_url %}
 
 {% block header %}
     <!-- Page Header -->

--- a/templates/tags.html
+++ b/templates/tags.html
@@ -18,7 +18,7 @@
   {% set selected_color = HEADER_COLOR %}
 {% endif %}
 
-{% block canonical_url %}<link href="{{ SITEURL }}/tags" rel="canonical" />{% endblock canonical_url %}
+{% block canonical_url %}<link href="{{ SITEURL }}/{{ TAGS_SAVE_AS }}" rel="canonical" />{% endblock canonical_url %}
 
 {% block header %}
     <!-- Page Header -->


### PR DESCRIPTION
The old version of Attila **Hard Codes** the Canonical values for the **Categories, Authors and Tags** pages.

This PR uses the **CATEGORIES_SAVE_AS, AUTHORS_SAVE_AS and TAGS_SAVE_AS** values set in [pelicanconf.py](https://github.com/arulrajnet/attila-demo/blob/master/pelicanconf.py).

For example:

```jinja
{% block canonical_url %}<link href="{{ SITEURL }}/authors" rel="canonical" />{% endblock canonical_url %}
```

Becomes:

```jinja
{% block canonical_url %}<link href="{{ SITEURL }}/{{ AUTHORS_SAVE_AS }}" rel="canonical" />{% endblock canonical_url %}

```